### PR TITLE
fix #6: set mpv option vo(video output) to libmpv

### DIFF
--- a/Src/LibMpv.Avalonia/OpenGlView.cs
+++ b/Src/LibMpv.Avalonia/OpenGlView.cs
@@ -28,6 +28,8 @@ public class OpenGlView : OpenGlControlBase, IVideoView
 
     protected override void OnOpenGlInit(GlInterface gl)
     {
+
+        MpvContext.SetOptionString("vo", "libmpv");
         if (_getProcAddress != null) { return; }
         
         _getProcAddress = gl.GetProcAddress;


### PR DESCRIPTION
See https://github.com/mpv-player/mpv/discussions/13974

> The second breaking change was the removal of libmpv as the default VO. It is listed in the [client api changes](https://github.com/mpv-player/mpv/blob/d255f31f982c9b424c399ea5ed4061b5907ce389/DOCS/client-api-changes.rst), but it was difficult for me to understand if it was the cause of my problem and how to fix it. Because libmpv was the default VO, it was never documented that you had to set the VO when embedding mpv in an application. But now all those applications need to do it. All the [libmpv examples](https://github.com/mpv-player/mpv-examples/tree/master/libmpv) that embed a player are probably broken (I only tried the SDL one and it indeed renders the video in an external window). The fix was pretty simple (add a mpv_set_option_string(mpv, "vo", "libmpv")), but it was not obvious when I read the client api change note.